### PR TITLE
disable "congé" and "rtt" display as values are wrong

### DIFF
--- a/Web/menu_genymobile-2012.php
+++ b/Web/menu_genymobile-2012.php
@@ -68,7 +68,7 @@ $geny_ic = new GenyIntranetCategory();
 			<span class="sdt_active"></span>
 			<span class="sdt_wrap">
 				<span class="sdt_link"><?php echo $profile->login ?></span>
-				<span class="sdt_descr"><?php echo $profile->firstname." ".$profile->lastname ; ?><br/><br/><span class="sdt_descr_more">CRA remplies: <?php echo $completion; ?>%<br/>Congés dispo : <?php echo $hs_remaining;?> j<br/>Notif. non lues : <span id='menu_notification_count'>7</span></span></span>
+				<span class="sdt_descr"><?php echo $profile->firstname." ".$profile->lastname ; ?><br/><br/><span class="sdt_descr_more">CRA remplies: <?php echo $completion; ?>%<!--<br/>Congés dispo : <?php echo $hs_remaining;?> j--><br/>Notif. non lues : <span id='menu_notification_count'>7</span></span></span>
 			</span>
 		</a>
 	</li>

--- a/Web/submodules/profile_summary.php
+++ b/Web/submodules/profile_summary.php
@@ -198,6 +198,7 @@ function ceAgreementToHtml($type,$ce_id,$agreement,$theme,$current_profile,$cons
 				<strong>Group Leader : </strong> <?php $gl = new GenyProfile( $geny_pmd->group_leader_id ); echo GenyTools::getProfileDisplayName( $gl ); ?><br/>
 				<strong>Technology Leader : </strong> <?php $gl = new GenyProfile( $geny_pmd->technology_leader_id ); echo GenyTools::getProfileDisplayName( $gl ); ?>
 			</li>
+<!--
 			<?php
 				if( ($prev_hs_cp->count_acquired - $prev_hs_cp->count_taken) > 0 && $prev_hs_cp->count_remaining > 0 ){
 			?>
@@ -234,6 +235,7 @@ function ceAgreementToHtml($type,$ce_id,$agreement,$theme,$current_profile,$cons
 				<strong>Congés pris : </strong><?php echo $hs_rtt->count_taken; ?><br/>
 				<strong>Congés restant : </strong><?php echo $hs_rtt->count_remaining; ?>
 			</li>
+-->
 			<?php
 				$cp_pmd = new GenyProfileManagementData();
 				$cp_pmd->loadProfileManagementDataByProfileId($geny_profile->id);


### PR DESCRIPTION
As discussed during the last Employee Delegate meeting, the value of
day off count ("congé" and "rtt") are wrong.
This is a problem for newcommer.
Until a better solution is found, this information should be hidden and
employee should refer to the payslip.
