### PR TITLE
Fix mixed content font loading

### DIFF
--- a/header.php
+++ b/header.php
@@ -144,9 +144,7 @@ echo $header_title
 
 <link rel="shortcut icon" href="images/favicon.ico" /> 
 
-<!-- <link href='http://fonts.googleapis.com/css?family=Droid+Sans:regular,bold' rel='stylesheet' type='text/css' /> -->
-<!--<link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>-->
-<link href='http://fonts.googleapis.com/css?family=Lato:400,100,700italic' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Lato:400,100,700italic' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" type="text/css" href="js/Gritter/css/jquery.gritter.css" />
 <link rel="stylesheet" href="js/DataTables/media/css/demo_table_jui.css" type="text/css" media="screen" charset="utf-8" />
 <link rel="stylesheet" type="text/css" href="styles/<?php echo $web_config->theme ?>/main.css" media="screen" />


### PR DESCRIPTION
Avoid external http/https url mix by using https for google font loading

![2018-01-08-025036_1162x87_scrot](https://user-images.githubusercontent.com/2337482/34668031-6d8674f8-f420-11e7-9ca7-f27d4ffa3a26.png)
